### PR TITLE
Allow use of DateTime objects in Timesheet request #5

### DIFF
--- a/src/Api/TimesheetApi.php
+++ b/src/Api/TimesheetApi.php
@@ -754,14 +754,14 @@ class TimesheetApi
             $begin = ObjectSerializer::serializeCollection($begin, '', true);
         }
         if (null !== $begin) {
-            $queryParams['begin'] = $begin;
+            $queryParams['begin'] = ObjectSerializer::toString($begin);
         }
         // query params
         if (\is_array($end)) {
             $end = ObjectSerializer::serializeCollection($end, '', true);
         }
         if (null !== $end) {
-            $queryParams['end'] = $end;
+            $queryParams['end'] = ObjectSerializer::toString($end);
         }
         // query params
         if (\is_array($exported)) {
@@ -796,7 +796,7 @@ class TimesheetApi
             $modifiedAfter = ObjectSerializer::serializeCollection($modifiedAfter, '', true);
         }
         if (null !== $modifiedAfter) {
-            $queryParams['modified_after'] = $modifiedAfter;
+            $queryParams['modified_after'] = ObjectSerializer::toString($modifiedAfter);
         }
 
         if ($multipart) {

--- a/src/ObjectSerializer.php
+++ b/src/ObjectSerializer.php
@@ -41,7 +41,7 @@ use Fiteco\KimaiClient\Model\ModelInterface;
 class ObjectSerializer
 {
     /** @var string */
-    private static $dateTimeFormat = \DateTime::ATOM;
+    private static $dateTimeFormat = 'Y-m-d\TH:i:s';
 
     /**
      * Change the date format.


### PR DESCRIPTION
Hallo, this work for me to solve problem #5 
I do not know whole library functionality yet.  Maybe  ``` ObjectSerializer::$dateTimeFormat = 'Y-m-d\TH:i:s'; ``` is not good idea. 
But the default  DateTimeInterface::ATOM was not accepted by API