### PR TITLE
Allow use of DateTime objects in Projects request

### DIFF
--- a/src/Api/ProjectApi.php
+++ b/src/Api/ProjectApi.php
@@ -379,14 +379,14 @@ class ProjectApi
             $start = ObjectSerializer::serializeCollection($start, '', true);
         }
         if (null !== $start) {
-            $queryParams['start'] = $start;
+            $queryParams['start'] = ObjectSerializer::toString($start);
         }
         // query params
         if (\is_array($end)) {
             $end = ObjectSerializer::serializeCollection($end, '', true);
         }
         if (null !== $end) {
-            $queryParams['end'] = $end;
+            $queryParams['end'] = ObjectSerializer::toString($end);
         }
         // query params
         if (\is_array($ignoreDates)) {


### PR DESCRIPTION
Another case related to #5 
I'll maybe find another places to fix in future.
